### PR TITLE
Fix typo in v3 separator menu popup

### DIFF
--- a/v3-developer/data/popup/index.html
+++ b/v3-developer/data/popup/index.html
@@ -7,7 +7,7 @@
 <body>
   <div id="form" title="Search Document (r: regexp)
 
-Prss Enter to find the next match
+Press Enter to find the next match
 Press Shift + Enter to find the previous match
 Press Enter or Shift + Enter to add a query to the history list for this domain">
     <div id="tools">
@@ -19,7 +19,7 @@ Press Enter or Shift + Enter to add a query to the history list for this domain"
 [ ]: Use space as the separator
 [,]: Use comma as the separator
 [;]: Use semicolon as the separator
-[|]: Use semicolon as the separator
+[|]: Use vertical bar as the separator
 [n]: Do not use any separator">
           <option value=" ">[ ]</option>
           <option value=",">[,]</option>

--- a/v3/data/popup/index.html
+++ b/v3/data/popup/index.html
@@ -16,7 +16,7 @@
     [ ]: Use space as the separator
     [,]: Use comma as the separator
     [;]: Use semicolon as the separator
-    [|]: Use semicolon as the separator
+    [|]: Use vertical bar as the separator
     [n]: Do not use any separator">
           <option value=" ">[ ]</option>
           <option value=",">[,]</option>


### PR DESCRIPTION
The menu listed both ';' and '|' as semicolon, which should be fixed with this edit in the index.html files.